### PR TITLE
Update `.env` to not provide empty keys

### DIFF
--- a/.env
+++ b/.env
@@ -1,8 +1,9 @@
-Notifier_Redirecter_Database__DatabaseName=database.db
-Notifier_Redirecter_Database__Password=
-Notifier_Redirecter_Discord__Debug_Guild_Id=
-Notifier_Redirecter_Discord__Token=
-Notifier_Redirecter_Discord__Prefixes__0=n!
-Notifier_Redirecter_Discord__Prefixes__1=n?
-Notifier_Redirecter_Logging__Level=Debug
-Notifier_Redirecter_Logging__Overrides__DSharpPlus=Information
+# Uncomment the environment variables as needed.
+#Notifier_Redirecter_Database__DatabaseName=database.db
+#Notifier_Redirecter_Database__Password=
+#Notifier_Redirecter_Discord__Debug_Guild_Id=
+#Notifier_Redirecter_Discord__Token=
+#Notifier_Redirecter_Discord__Prefixes__0=n!
+#Notifier_Redirecter_Discord__Prefixes__1=n?
+#Notifier_Redirecter_Logging__Level=Debug
+#Notifier_Redirecter_Logging__Overrides__DSharpPlus=Information

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,3 +8,5 @@ services:
     env_file: .env
     volumes:
       - ./database.db:/src/database.db
+      - ./logs:/src/logs
+      - ./res/config.json:/src/config.json

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -74,7 +74,7 @@ public sealed class Program
         LoggerFactory = Services.BuildServiceProvider().GetRequiredService<ILoggerFactory>();
         Logger = LoggerFactory.CreateLogger<Program>();
 
-        if (Configuration.GetValue<string>("discord:token") is null)
+        if (string.IsNullOrWhiteSpace(Configuration.GetValue<string>("discord:token")))
         {
             Logger.LogCritical("Discord token parameter is required but not found.");
             Environment.Exit(1);


### PR DESCRIPTION
Previously the `.env` file provided empty keys, thus overriding the `config.json`.
Additionally fixed the token null check in the static constructor to actually work when there isn't a token set.

All changes tested.